### PR TITLE
Separating the before_filter from has_mobile_fu

### DIFF
--- a/lib/mobile-fu.rb
+++ b/lib/mobile-fu.rb
@@ -34,10 +34,9 @@ module ActionController
       #      has_mobile_fu true
       #    end
 
-      def has_mobile_fu(test_mode = nil, &test_mode_block)
+      def has_mobile_fu(test_mode = nil)
+        raise ArgumentError, "test_mode argument to has_mobile_fu is no longer supported, please invoke set_device_type as or in a before_filter instead" unless test_mode.nil?
         include ActionController::MobileFu::InstanceMethods
-        @@test_mode = test_mode || block
-        before_filter :set_device_type
         
         helper_method :is_mobile_device?
         helper_method :in_mobile_view?
@@ -47,18 +46,8 @@ module ActionController
     end
 
     module InstanceMethods
-
-      def set_device_type
-        # see if we want to force mobile
-        force_mobile = if @@test_mode.is_a?(Proc)
-          @@test_mode.call
-        elsif (@@test_mode.is_a?(String) || @@test_mode.is_a?(Symbol)) && self.respond_to?(@@test_mode)
-          self.send(@@test_mode)
-        else
-          @@test_mode
-        end
-        
-        force_mobile ? :force_mobile_format : :set_mobile_format
+      def set_device_type(force_mobile = false)
+        force_mobile ? force_mobile_format : set_mobile_format
       end
 
       # Forces the request format to be :mobile
@@ -104,7 +93,6 @@ module ActionController
         request.user_agent.to_s.downcase.include? type.to_s.downcase
       end
     end
-
   end
 
 end


### PR DESCRIPTION
Hey Ben,

In playing around more with has_mobile_fu, I realized it would be valuable to separate the before_filter (determining whether a request should be mobile or not) from the has_mobile_fu method, which includes the instance methods, etc.  

When the before_filter was being set up in the class method, I found I couldn't reach the level of control I needed over how requests were served.  For instance, I want to be able to trigger mobile mode on a request-by-request basis, which I couldn't do if I had to decide on at the class level whether to force mobile mode.  Having to invoke the before_filter myself also gave me the flexibility to trigger it from other functions, where I can mess with the session flag or do other necessary calculations, like so:

``` ruby
  def setup_mobile
    # we allow two parameters:
    # :desktop, to force mobile devices to render in desktop mode
    # :mobile,  to force mobile mode on desktop browsers
    # we manually set the session value to persist the setting
    # (leaving it nil by default, see mobile_mode?)
    session[:mobile_view] = false if params[:desktop]
    session[:mobile_view] = true if params[:mobile]
    set_device_type 
  end
```

Also, I removed what looked like old code that seemed to reference class variables that never get defined and hence always throw errors.  (Feel free to revert that if I misunderstood.)

Hope it's useful!

Best,

Alex
