### PR TITLE
fix: error when controller do not respond to is_mobile_device?

### DIFF
--- a/lib/mobile-fu/helper.rb
+++ b/lib/mobile-fu/helper.rb
@@ -9,7 +9,7 @@ module MobileFu
       sources.each do |source|
         mobilized_sources << source
 
-        device_names = is_mobile_device? ? ['mobile', mobile_device.downcase] : []
+        device_names = respond_to?(:is_mobile_device?) && is_mobile_device? ? ['mobile', mobile_device.downcase] : []
 
         device_names.compact.each do |device_name|
           possible_source = "#{source.to_s.gsub '.css', ''}_#{device_name}.css"


### PR DESCRIPTION
Useful when using other framework, like Typus, that doesn't use our ApplicationController
