### PR TITLE
Fix for Rails 3.1

### DIFF
--- a/lib/mobile-fu.rb
+++ b/lib/mobile-fu.rb
@@ -70,6 +70,11 @@ module ActionController
       #     
       #     def show
       #       # Mobile format will be set as normal here if user is on a mobile device
+      #     end
+      #   end
+      def has_no_mobile_fu_for(*actions)
+        @mobile_exempt_actions = actions
+      end
     end
 
     module InstanceMethods


### PR DESCRIPTION
The stylesheet tag helper wasn't working correctly on Rails 3.1 due to the timing of the method chaining call. I've changed the "include" methods to work the Rails 3 way using hooks to fix the timing, and gated it based on which version of rails is loading the gem.
