### PR TITLE
Rails 3.1 asset pipeline and ERB/SASS CSS fixes to stylesheet_link_tag_with_mobilization

### DIFF
--- a/lib/mobile-fu/helper.rb
+++ b/lib/mobile-fu/helper.rb
@@ -6,15 +6,33 @@ module MobileFu
 
     def stylesheet_link_tag_with_mobilization(*sources)
       mobilized_sources = Array.new
+      
+      # Figure out where stylesheets live, which differs depending if the asset
+      # pipeline is used or not.
+      stylesheets_dir = config.stylesheets_dir # Rails.root/public/stylesheets
+      
+      # Look for mobilized stylesheets in the app/assets path if asset pipeline
+      # is enabled, because public/stylesheets will be missing in development
+      # mode without precompiling assets first, and may also contain multiple
+      # stylesheets with similar names because of checksumming during
+      # precompilation.
+      if Rails.application.config.respond_to?(:assets) # don't break pre-rails3.1
+        if Rails.application.config.assets.enabled
+          stylesheets_dir = File.join(Rails.root, 'app/assets/stylesheets/')
+        end
+      end
+      
+      device_names = respond_to?(:is_mobile_device?) && is_mobile_device? ? ['mobile', mobile_device.downcase] : []
+      
       sources.each do |source|
         mobilized_sources << source
 
-        device_names = respond_to?(:is_mobile_device?) && is_mobile_device? ? ['mobile', mobile_device.downcase] : []
-
         device_names.compact.each do |device_name|
-          possible_source = "#{source.to_s.gsub '.css', ''}_#{device_name}.css"
-          path = File.join config.stylesheets_dir, possible_source
-          mobilized_sources << possible_source if File.exist?(path)
+          # support ERB and/or SCSS extensions (e.g., mobile.css.erb, mobile.css.scss.erb)
+          possible_source = source.to_s.sub(/\.css.*$/, '') + "_#{device_name}"
+
+          mobilized_files = Dir.glob(File.join(stylesheets_dir, "#{possible_source}.css*")).map { |f| f.sub(stylesheets_dir, '') }
+          mobilized_sources += mobilized_files.map { |f| f.sub(/\.css.*/, '') }
         end
       end
 


### PR DESCRIPTION
Look for stylesheets in Rails.root/app/assets/stylesheets instead of
public/stylesheets when the asset pipeline is enabled.

Support ERB and SASS stylesheets (.css.erb, .css.scss.erb) files in addition
to simple .css files.
