### PR TITLE
Don't check request.xhr? to determine if this is mobile format

### DIFF
--- a/lib/mobile-fu.rb
+++ b/lib/mobile-fu.rb
@@ -112,10 +112,10 @@ module ActionController
 
       def set_mobile_format
         if !mobile_exempt? && is_mobile_device?
-          request.format = session[:mobile_view] == false ? :html : :mobile
+          request.format = :mobile unless session[:mobile_view] == false
           session[:mobile_view] = true if session[:mobile_view].nil?
         elsif !mobile_exempt? && is_tablet_device?
-          request.format = session[:tablet_view] == false ? :html : :tablet
+          request.format = :tablet unless session[:tablet_view] == false
           session[:tablet_view] = true if session[:tablet_view].nil?
         end
       end


### PR DESCRIPTION
This commit removes the checks for `request.xhr?` in `set_mobile_format`.  This also changes the conditional to set the format to `:mobile` if `session[:mobile_view]` is set, but not to assume it should be `:html` otherwise.
