### PR TITLE
Fixes is_mobile_device? method to ensure that a tablet device is not detected as a mobile device

### DIFF
--- a/lib/mobile-fu.rb
+++ b/lib/mobile-fu.rb
@@ -140,7 +140,7 @@ module ActionController
       # the device making the request is matched to a device in our regex.
 
       def is_mobile_device?
-        !!mobile_device
+        !is_tablet_device? && !!mobile_device
       end
 
       def is_tablet_device?


### PR DESCRIPTION
Currently, mobile-fu thinks that iPad is a mobile device. Consequently, the "set_mobile_format" method sets :mobile format for requests from iPad as well.

This pull request fixes that.
