### PR TITLE
Add Nexus 7 to tablet regex - Lowercased!

### DIFF
--- a/lib/mobile-fu.rb
+++ b/lib/mobile-fu.rb
@@ -33,7 +33,7 @@ module ActionController
   module MobileFu
     # These are various strings that can be found in tablet devices.  Please feel free
     # to add on to this list.
-    TABLET_USER_AGENTS =  /ipad|android 3.0|xoom|sch-i800|playbook|tablet|kindle|honeycomb|Nexus 7/.freeze
+    TABLET_USER_AGENTS =  /ipad|android 3.0|xoom|sch-i800|playbook|tablet|kindle|honeycomb|nexus 7/.freeze
 
     def self.included(base)
       base.extend ClassMethods


### PR DESCRIPTION
The previous pull request had the "N" in Nexus 7 capitalized, but the matching compares to a down cased user agent so it never matches. This fixes that fix.
