### PR TITLE
rebase of #21 fix for rails 4

### DIFF
--- a/lib/mobile-fu.rb
+++ b/lib/mobile-fu.rb
@@ -168,6 +168,42 @@ module ActionController
   end
 end
 
+module ActionView
+  class PathSet < Array
+
+    def find_with_default_template(path, prefix = nil, partial = false, details = {}, key = nil)
+      if prefix == "layouts"
+        # Layouts have their own way of managing fallback, better leave them alone
+        find_without_default_template(path, prefix, partial, details, key)
+      else
+        begin
+          find_without_default_template(path, prefix, partial, details, key)
+        rescue MissingTemplate => e
+          raise e if details[:formats] == [:html]
+          html_details = details.dup.merge(:formats => [:html])
+          find_without_default_template(path, prefix, partial, html_details, key)
+        end
+      end
+    end
+    alias_method_chain :find, :default_template
+
+  end
+  
+  class Resolver
+    
+    def cached(key, prefix, name, partial)
+      return yield unless key && caching?
+      cache_content = yield
+      if cache_content.empty?
+        []
+      else
+        @cached[key][prefix][name][partial] ||= cache_content
+      end
+    end
+    
+  end
+end
+
 if Rails::VERSION::MAJOR < 3
   ActionController::Base.send :include, ActionController::MobileFu
   ActionView::Base.send :include, MobileFu::Helper

--- a/lib/mobile-fu.rb
+++ b/lib/mobile-fu.rb
@@ -168,41 +168,27 @@ module ActionController
   end
 end
 
+# the following code are obtained from https://github.com/cannikin/format_fallback
 module ActionView
-  class PathSet < Array
-
-    def find_with_default_template(path, prefix = nil, partial = false, details = {}, key = nil)
+  class PathSet
+    def find_with_default_template(path, prefix = nil, partial = false, details = {}, keys = [], key = nil)
       if prefix == "layouts"
         # Layouts have their own way of managing fallback, better leave them alone
-        find_without_default_template(path, prefix, partial, details, key)
+        find_without_default_template(path, prefix, partial, details, keys, key)
       else
         begin
-          find_without_default_template(path, prefix, partial, details, key)
+          find_without_default_template(path, prefix, partial, details, keys, key)
         rescue MissingTemplate => e
           raise e if details[:formats] == [:html]
           html_details = details.dup.merge(:formats => [:html])
-          find_without_default_template(path, prefix, partial, html_details, key)
+          find_without_default_template(path, prefix, partial, html_details, keys, key)
         end
       end
     end
     alias_method_chain :find, :default_template
-
-  end
-  
-  class Resolver
-    
-    def cached(key, prefix, name, partial)
-      return yield unless key && caching?
-      cache_content = yield
-      if cache_content.empty?
-        []
-      else
-        @cached[key][prefix][name][partial] ||= cache_content
-      end
-    end
-    
   end
 end
+# end of code obtained from https://github.com/cannikin/format_fallback
 
 if Rails::VERSION::MAJOR < 3
   ActionController::Base.send :include, ActionController::MobileFu


### PR DESCRIPTION
This is a rebase of #21 that let's `has_mobile_fu` be used in ApplicationController, and properly falls back to html views when no mobile override is present. It should also work with Rails 3 but has not been tested. It likely will _not_ work with Rails 2, as the method signature for the method it overrides has changed (the issue that stalled #21 in the first place).
