### PR TITLE
Added a part in the README about excluding mimetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ session[:tablet_view] # => Set to true if request format is :tablet and false
                            if set to :html
 ```
 
-If you want to exclude all actions from rendering a specific mimetype (ie :mobile or :tablet)
+If you want to use the default response templates, like index.html.erb, instead of the index.tablet.erb you can
+exclude the tablet rendering from beeing used:
 you can create a `before_filter` and put it before the has_mobile_fu call
 
 ```ruby


### PR DESCRIPTION
Added a part in the README about excluding all views from rendering a specific mime type, since it was not clear at first you had to put the before_filter before the has_mobile_fu call
