### PR TITLE
fall back to html if the format is something we cant handle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 pkg/*
 vendor/ruby
 *.DS_Store
+.idea/

--- a/lib/mobile-fu.rb
+++ b/lib/mobile-fu.rb
@@ -127,12 +127,13 @@ module ActionController
 
       def set_mobile_format
         if !request.format.respond_to?(:html?)
-          request.format = 'html'
+          request.format = :html
         else
-          if request.format.html? && mobile_action? && is_mobile_device? && !request.xhr?
+          is_html = request.format.html?
+          if is_html && mobile_action? && is_mobile_device? && !request.xhr?
             request.format = :mobile unless session[:mobile_view] == false
             session[:mobile_view] = true if session[:mobile_view].nil?
-          elsif request.format.html? && mobile_action? && is_tablet_device? && !request.xhr?
+          elsif is_html && mobile_action? && is_tablet_device? && !request.xhr?
             request.format = :tablet unless session[:tablet_view] == false
             session[:tablet_view] = true if session[:tablet_view].nil?
           end

--- a/lib/mobile-fu.rb
+++ b/lib/mobile-fu.rb
@@ -126,12 +126,16 @@ module ActionController
       # 'Tablet' view.
 
       def set_mobile_format
-        if request.format.html? && mobile_action? && is_mobile_device? && !request.xhr?
-          request.format = :mobile unless session[:mobile_view] == false
-          session[:mobile_view] = true if session[:mobile_view].nil?
-        elsif request.format.html? && mobile_action? && is_tablet_device? && !request.xhr?
-          request.format = :tablet unless session[:tablet_view] == false
-          session[:tablet_view] = true if session[:tablet_view].nil?
+        if !request.format.respond_to?(:html?)
+          request.format = 'html'
+        else
+          if request.format.html? && mobile_action? && is_mobile_device? && !request.xhr?
+            request.format = :mobile unless session[:mobile_view] == false
+            session[:mobile_view] = true if session[:mobile_view].nil?
+          elsif request.format.html? && mobile_action? && is_tablet_device? && !request.xhr?
+            request.format = :tablet unless session[:tablet_view] == false
+            session[:tablet_view] = true if session[:tablet_view].nil?
+          end
         end
       end
 

--- a/spec/mobile-fu_spec.rb
+++ b/spec/mobile-fu_spec.rb
@@ -26,7 +26,7 @@ describe "Changes to ActionController" do
       let(:controller_stubs) do
         {
           request: {
-            headers: {"X_MOBILE_DEVICE" => "blah" },
+            headers: { "X_MOBILE_DEVICE" => "blah" },
             format: mock_format
           }
         }

--- a/spec/mobile-fu_spec.rb
+++ b/spec/mobile-fu_spec.rb
@@ -1,4 +1,4 @@
-require_relative 'spec_helper'
+require_relative "spec_helper"
 
 describe "Changes to ActionController" do
 
@@ -8,7 +8,7 @@ describe "Changes to ActionController" do
   describe "set_mobile_format" do
 
     describe "for an unknown format" do
-      let(:controller_stubs) { { :request => { :format => 'php' } } }
+      let(:controller_stubs) { { request: { format: "php" } } }
       it "should not raise an error" do
         controller.set_mobile_format
       end
@@ -26,9 +26,9 @@ describe "Changes to ActionController" do
       }
       let(:controller_stubs) do
         {
-          :request => {
-            :headers => {'X_MOBILE_DEVICE' => 'blah' },
-            :format => mock_format
+          request: {
+            headers: {"X_MOBILE_DEVICE" => "blah" },
+            format: mock_format
           }
         }
       end
@@ -97,7 +97,7 @@ class InstanceMethodDummy
   end
 
   def params
-   {:action => 'show'}.merge(@stubs[:params] || {})
+   {action: "show"}.merge(@stubs[:params] || {})
   end
 
 end

--- a/spec/mobile-fu_spec.rb
+++ b/spec/mobile-fu_spec.rb
@@ -6,7 +6,6 @@ describe "Changes to ActionController" do
   let(:controller) { InstanceMethodDummy.new(controller_stubs) }
 
   describe "set_mobile_format" do
-
     describe "for an unknown format" do
       let(:controller_stubs) { { request: { format: "php" } } }
       it "should not raise an error" do
@@ -19,11 +18,11 @@ describe "Changes to ActionController" do
     end
 
     describe "for a known format (that responds to html?)" do
-      let(:mock_format) {
-        fmt = mock()
+      let(:mock_format) do
+        fmt = mock
         fmt.stubs(:html?).returns(true)
         fmt
-      }
+      end
       let(:controller_stubs) do
         {
           request: {
@@ -35,12 +34,10 @@ describe "Changes to ActionController" do
       it "should not raise an error" do
         controller.set_mobile_format
       end
-
       it "should maintain the right format" do
         controller.set_mobile_format
         controller.request.format.must_be_same_as :mobile
       end
-
     end
   end
 
@@ -61,7 +58,6 @@ describe "Changes to ActionController" do
 end
 
 class DummyRequest
-
   attr_accessor :user_agent
   attr_accessor :format
   attr_accessor :headers
@@ -78,7 +74,6 @@ class DummyRequest
 end
 
 class InstanceMethodDummy
-
   include ActionController::MobileFu::InstanceMethods
 
   attr_accessor :user_agent
@@ -97,7 +92,6 @@ class InstanceMethodDummy
   end
 
   def params
-   {action: "show"}.merge(@stubs[:params] || {})
+    { action: "show" }.merge(@stubs[:params] || {})
   end
-
 end


### PR DESCRIPTION
We've been seeing the following error with bad formats (like .php)

```
…undle/ruby/2.1.0/gems/mobile-fu-1.3.1/lib/mobile-fu.rb: 129:in `set_mobile_format'
…undle/ruby/2.1.0/gems/mobile-fu-1.3.1/lib/mobile-fu.rb: 104:in `set_request_format'
…s/activesupport-3.2.19/lib/active_support/callbacks.rb: 451:in   `_run__3927665085735429995__process_action__462404612733862062__callbacks'
...
```

The root of the issue is that bad formats (I assume ones that mobile-fu is not looking for) don't respond to `html?`.  This fix falls back to html as the format if doesn't know how to ask `html?`.

I was unable to run the specs because `mocha/setup` was not available and I was not ready to debug the test suite.  I'm happy to add tests, if you can help get the framework working.
