### PR TITLE
Fix exception when request.format is nil

### DIFF
--- a/lib/mobile-fu.rb
+++ b/lib/mobile-fu.rb
@@ -126,6 +126,8 @@ module ActionController
       # 'Tablet' view.
 
       def set_mobile_format
+        return unless request.format
+        
         if request.format.html? && mobile_action? && is_mobile_device? && !request.xhr?
           request.format = :mobile unless session[:mobile_view] == false
           session[:mobile_view] = true if session[:mobile_view].nil?

--- a/lib/mobile-fu.rb
+++ b/lib/mobile-fu.rb
@@ -127,7 +127,6 @@ module ActionController
 
       def set_mobile_format
         return unless request.format
-        
         if request.format.html? && mobile_action? && is_mobile_device? && !request.xhr?
           request.format = :mobile unless session[:mobile_view] == false
           session[:mobile_view] = true if session[:mobile_view].nil?


### PR DESCRIPTION
This fixes an exception when request.format is nil, which can happen when the request does not map to a defined Mime type (e.g., php). A number of forks have made this same change, and this is a duplicate of #61 which was not accepted due to a lack of description of the problem.